### PR TITLE
Feature/main refactor

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   audit:
+    name: Security audit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,8 @@ jobs:
         job:
           - os: macos-latest
             os-name: macos
-            binary-postfix: ""
           - os: ubuntu-latest
             os-name: linux
-            binary-postfix: ""
           - os: windows-latest
             os-name: windows
             binary-postfix: ".exe"

--- a/src/chip.rs
+++ b/src/chip.rs
@@ -2,7 +2,8 @@
 
 use strum::{Display, EnumString};
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Display, EnumString)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Display, EnumString)]
+
 pub enum Chip {
     /// Xtensa LX7 based dual core
     #[strum(serialize = "esp32")]

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -7,6 +7,7 @@ use crate::utils::get_home_dir;
 use anyhow::{Context, Result};
 use embuild::{espidf, espidf::EspIdfRemote, git};
 use log::{debug, info};
+use std::collections::HashSet;
 use std::{
     collections::hash_map::DefaultHasher,
     env,
@@ -54,7 +55,7 @@ pub struct EspIdfRepo {
     /// Installation directory.
     pub install_path: PathBuf,
     /// ESP targets.
-    pub targets: Vec<Chip>,
+    pub targets: HashSet<Chip>,
 }
 
 impl EspIdfRepo {
@@ -158,7 +159,7 @@ impl EspIdfRepo {
     }
 
     /// Create a new instance with the propper arguments.
-    pub fn new(version: &str, minified: bool, targets: Vec<Chip>) -> EspIdfRepo {
+    pub fn new(version: &str, minified: bool, targets: HashSet<Chip>) -> EspIdfRepo {
         let install_path = PathBuf::from(get_tools_path());
         debug!(
             "{} ESP-IDF install path: {}",

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -16,9 +16,9 @@ use std::{
 };
 use strum::{Display, EnumIter, EnumString, IntoStaticStr};
 
-const DEFAULT_GIT_REPOSITORY: &str = "https://github.com/espressif/esp-idf";
+pub const DEFAULT_GIT_REPOSITORY: &str = "https://github.com/espressif/esp-idf";
 
-pub const DEFAULT_CMAKE_GENERATOR: Generator = {
+const DEFAULT_CMAKE_GENERATOR: Generator = {
     // No Ninja builds for linux=aarch64 from Espressif yet
     #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
     {
@@ -149,6 +149,11 @@ impl EspIdfRepo {
             remove_dir_all(espidf_dir.join("tools").join("test_idf_size"))?;
         }
 
+        #[cfg(windows)]
+        exports.push(format!("$Env:IDF_TOOLS_PATH=\"{}\"", get_tools_path()));
+        #[cfg(unix)]
+        exports.push(format!("export IDF_TOOLS_PATH=\"{}\"", get_tools_path()));
+
         Ok(exports)
     }
 
@@ -180,7 +185,7 @@ pub fn get_install_path(repo: EspIdfRemote) -> PathBuf {
     };
     // Replace all directory separators with a dash `-`, so that we don't create
     // subfolders for tag or branch names that contain such characters.
-    let repo_dir = repo_dir.replace(&['/', '\\'], "-");
+    let repo_dir = repo_dir.replace(['/', '\\'], "-");
 
     let mut install_path = PathBuf::from(get_tools_path());
     install_path = install_path.join(PathBuf::from(format!("esp-idf-{}", repo_url_hash)));

--- a/src/gcc_toolchain.rs
+++ b/src/gcc_toolchain.rs
@@ -7,6 +7,7 @@ use crate::utils::download_file;
 use anyhow::Result;
 use embuild::espidf::EspIdfVersion;
 use log::{debug, info};
+use std::collections::HashSet;
 
 const DEFAULT_GCC_REPOSITORY: &str = "https://github.com/espressif/crosstool-NG/releases/download";
 const DEFAULT_GCC_RELEASE: &str = "esp-2021r2-patch3";
@@ -119,7 +120,7 @@ pub fn get_ulp_toolchain_name(chip: Chip, version: Option<&EspIdfVersion>) -> Op
 }
 
 /// Installs GCC toolchain the selected chips.
-pub fn install_gcc_targets(targets: Vec<Chip>) -> Result<Vec<String>> {
+pub fn install_gcc_targets(targets: HashSet<Chip>) -> Result<Vec<String>> {
     info!("{} Installing gcc for build targets", emoji::WRENCH);
     let mut exports: Vec<String> = Vec::new();
     for target in targets {

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,7 @@ fn install(args: InstallOpts) -> Result<()> {
         exports.extend(repo.install()?);
         extra_crates.insert(RustCrate::new("ldproxy"));
     } else {
-        exports.extend(install_gcc_targets(targets).unwrap());
+        exports.extend(install_gcc_targets(targets)?);
     }
 
     debug!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,10 @@ use crate::llvm_toolchain::LlvmToolchain;
 use crate::rust_toolchain::{
     check_rust_installation, get_rustup_home, install_riscv_target, RustCrate, RustToolchain,
 };
+#[cfg(windows)]
+use crate::utils::check_arguments;
 use crate::utils::{
-    check_arguments, clear_dist_folder, export_environment, logging::initialize_logger,
-    parse_targets,
+    clear_dist_folder, export_environment, logging::initialize_logger, parse_targets,
 };
 use anyhow::Result;
 use clap::Parser;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use crate::rust_toolchain::{
     check_rust_installation, get_rustup_home, install_riscv_target, RustCrate, RustToolchain,
 };
 use crate::utils::{
-    clear_dist_folder, export_environment, logging::initialize_logger, parse_targets,
+    check_arguments, clear_dist_folder, export_environment, logging::initialize_logger,
+    parse_targets,
 };
 use anyhow::Result;
 use clap::Parser;
@@ -125,7 +126,7 @@ fn install(args: InstallOpts) -> Result<()> {
     initialize_logger(&args.log_level);
 
     info!("{} Installing esp-rs", emoji::DISC);
-    let targets: Vec<Chip> = parse_targets(&args.targets).unwrap();
+    let targets: HashSet<Chip> = parse_targets(&args.targets).unwrap();
     let mut extra_crates: HashSet<RustCrate> =
         args.extra_crates.split(',').map(RustCrate::new).collect();
     let mut exports: Vec<String> = Vec::new();
@@ -160,6 +161,9 @@ fn install(args: InstallOpts) -> Result<()> {
         args.profile_minimal,
         args.toolchain_version,
     );
+
+    #[cfg(windows)]
+    check_arguments(&targets, &args.espidf_version)?;
 
     check_rust_installation(&args.nightly_version)?;
 

--- a/src/rust_toolchain.rs
+++ b/src/rust_toolchain.rs
@@ -289,9 +289,9 @@ fn get_installer(host_triple: &str) -> &str {
 /// not, proceed to install them.
 pub fn check_rust_installation(nightly_version: &str) -> Result<()> {
     info!("{} Checking existing Rust installation", emoji::WRENCH);
-    match std::process::Command::new("rustup")
-        .arg("toolchain")
-        .arg("list")
+
+    match cmd!("rustup", "toolchain", "list")
+        .into_inner()
         .stdout(Stdio::piped())
         .output()
     {

--- a/src/rust_toolchain.rs
+++ b/src/rust_toolchain.rs
@@ -133,7 +133,7 @@ impl RustToolchain {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug)]
 pub struct BinstallCrate {
     /// Crate version.
     pub url: String,
@@ -143,7 +143,7 @@ pub struct BinstallCrate {
     pub fmt: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Hash, Eq, PartialEq, Debug)]
 pub struct RustCrate {
     /// Crate name.
     pub name: String,
@@ -152,7 +152,7 @@ pub struct RustCrate {
 }
 
 impl RustCrate {
-    /// Installs an extra crate.
+    /// Installs a crate.
     pub fn install(&self) -> Result<()> {
         cmd!("cargo", "install", "cargo-binstall").run()?;
         info!("{} Installing {} crate", emoji::WRENCH, self.name);
@@ -174,6 +174,52 @@ impl RustCrate {
             cmd!("cargo", "install", &self.name).run()?;
         }
         Ok(())
+    }
+
+    /// Create a crate instance.
+    pub fn new(name: &str) -> Self {
+        match name {
+            // "ldproxy" => {
+            //     RustCrate {
+            //         name: name.to_string(),
+            //         binstall: Some(BinstallCrate {
+            //             url: "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }.{ archive-format }".to_string(),
+            //             bin: "{ bin }{ binary-ext }".to_string(),
+            //             fmt: "zip".to_string(),
+            //         }),
+            //     }
+            // }
+            // "espflash" => {
+            //     RustCrate {
+            //         name: name.to_string(),
+            //         binstall: Some(BinstallCrate {
+            //             url: "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }.{ archive-format }".to_string(),
+            //             bin: "{ bin }{ binary-ext }".to_string(),
+            //             fmt: "zip".to_string(),
+            //         }),
+            //     }
+            // }
+            "cargo-generate" => {
+                RustCrate {
+                    name: name.to_string() + "@0.15.2",
+                    binstall: Some(BinstallCrate {
+                        url: "{ repo }/releases/download/v{ version }/{ name}-{ version }-{ target }.{ archive-format }".to_string(),
+                        bin: "{ bin }{ binary-ext }".to_string(),
+                        fmt: "tgz".to_string(),
+                    }),
+                }
+            }
+            // "wokwi-server" => {
+
+            // },
+            // "web-flash" => {
+
+            // },
+            _ => RustCrate {
+                name: name.to_string(),
+                binstall: None,
+            },
+        }
     }
 }
 
@@ -230,52 +276,6 @@ pub fn check_rust_installation(nightly_version: &str) -> Result<()> {
         }
     }
     Ok(())
-}
-
-/// Retuns the RustCrate from a given name.
-pub fn get_rust_crate(name: &str) -> RustCrate {
-    match name {
-        // "ldproxy" => {
-        //     RustCrate {
-        //         name: name.to_string(),
-        //         binstall: Some(BinstallCrate {
-        //             url: "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }.{ archive-format }".to_string(),
-        //             bin: "{ bin }{ binary-ext }".to_string(),
-        //             fmt: "zip".to_string(),
-        //         }),
-        //     }
-        // }
-        // "espflash" => {
-        //     RustCrate {
-        //         name: name.to_string(),
-        //         binstall: Some(BinstallCrate {
-        //             url: "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }.{ archive-format }".to_string(),
-        //             bin: "{ bin }{ binary-ext }".to_string(),
-        //             fmt: "zip".to_string(),
-        //         }),
-        //     }
-        // }
-        "cargo-generate" => {
-            RustCrate {
-                name: name.to_string() + "@0.15.2",
-                binstall: Some(BinstallCrate {
-                    url: "{ repo }/releases/download/v{ version }/{ name}-{ version }-{ target }.{ archive-format }".to_string(),
-                    bin: "{ bin }{ binary-ext }".to_string(),
-                    fmt: "tgz".to_string(),
-                }),
-            }
-        }
-        // "wokwi-server" => {
-
-        // },
-        // "web-flash" => {
-
-        // },
-        _ => RustCrate {
-            name: name.to_string(),
-            binstall: None,
-        },
-    }
 }
 
 /// Installs rustup

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,7 @@ use dirs::home_dir;
 use flate2::bufread::GzDecoder;
 use log::{debug, info};
 use std::{
+    collections::HashSet,
     fs::{create_dir_all, remove_dir_all, File},
     io::{copy, BufReader, Write},
     path::{Path, PathBuf},
@@ -34,27 +35,27 @@ pub fn clear_dist_folder() -> Result<()> {
 }
 
 /// Returns a vector of Chips from a comma or space separated string.
-pub fn parse_targets(targets: &str) -> Result<Vec<Chip>, String> {
+pub fn parse_targets(targets: &str) -> Result<HashSet<Chip>, String> {
     debug!("{} Parsing targets: {}", emoji::DEBUG, targets);
-    let mut chips: Vec<Chip> = Vec::new();
+    let mut chips: HashSet<Chip> = HashSet::new();
     if targets.contains("all") {
-        chips.push(Chip::ESP32);
-        chips.push(Chip::ESP32S2);
-        chips.push(Chip::ESP32S3);
-        chips.push(Chip::ESP32C3);
+        chips.insert(Chip::ESP32);
+        chips.insert(Chip::ESP32S2);
+        chips.insert(Chip::ESP32S3);
+        chips.insert(Chip::ESP32C3);
         return Ok(chips);
     }
-    let targets: Vec<&str> = if targets.contains(' ') || targets.contains(',') {
+    let targets: HashSet<&str> = if targets.contains(' ') || targets.contains(',') {
         targets.split([',', ' ']).collect()
     } else {
-        vec![targets]
+        vec![targets].into_iter().collect()
     };
     for target in targets {
         match target {
-            "esp32" => chips.push(Chip::ESP32),
-            "esp32s2" => chips.push(Chip::ESP32S2),
-            "esp32s3" => chips.push(Chip::ESP32S3),
-            "esp32c3" => chips.push(Chip::ESP32C3),
+            "esp32" => chips.insert(Chip::ESP32),
+            "esp32s2" => chips.insert(Chip::ESP32S2),
+            "esp32s3" => chips.insert(Chip::ESP32S3),
+            "esp32c3" => chips.insert(Chip::ESP32C3),
             _ => {
                 return Err(format!("Unknown target: {}", target));
             }
@@ -165,6 +166,24 @@ pub fn export_environment(export_file: &PathBuf, exports: &[String]) -> Result<(
         "{} This step must be done every time you open a new terminal.",
         emoji::WARN
     );
+    Ok(())
+}
+
+#[cfg(windows)]
+/// For Windows, we need to check that we are installing all the targets if we are installing esp-idf.
+pub fn check_arguments(targets: &HashSet<Chip>, espidf_version: &Option<String>) -> Result<()> {
+    if espidf_version.is_some()
+        && (!targets.contains(&Chip::ESP32)
+            || !targets.contains(&Chip::ESP32C3)
+            || !targets.contains(&Chip::ESP32S2)
+            || !targets.contains(&Chip::ESP32S3))
+    {
+        bail!(
+            "{} When installing esp-idf in Windows, only --targets \"all\" is supported.",
+            emoji::ERROR
+        );
+    }
+
     Ok(())
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -193,22 +193,29 @@ mod tests {
     use crate::Chip;
     #[test]
     fn test_parse_targets() {
-        assert_eq!(parse_targets("esp32"), Ok([Chip::ESP32].to_vec()));
+        assert_eq!(
+            parse_targets("esp32"),
+            Ok([Chip::ESP32].into_iter().collect())
+        );
         assert_eq!(
             parse_targets("esp32,esp32s2"),
-            Ok([Chip::ESP32, Chip::ESP32S2].to_vec())
+            Ok([Chip::ESP32, Chip::ESP32S2].into_iter().collect())
         );
         assert_eq!(
             parse_targets("esp32s3 esp32"),
-            Ok([Chip::ESP32S3, Chip::ESP32].to_vec())
+            Ok([Chip::ESP32S3, Chip::ESP32].into_iter().collect())
         );
         assert_eq!(
             parse_targets("esp32s3,esp32,esp32c3"),
-            Ok([Chip::ESP32S3, Chip::ESP32, Chip::ESP32C3].to_vec())
+            Ok([Chip::ESP32S3, Chip::ESP32, Chip::ESP32C3]
+                .into_iter()
+                .collect())
         );
         assert_eq!(
             parse_targets("all"),
-            Ok([Chip::ESP32, Chip::ESP32S2, Chip::ESP32S3, Chip::ESP32C3].to_vec())
+            Ok([Chip::ESP32, Chip::ESP32S2, Chip::ESP32S3, Chip::ESP32C3]
+                .into_iter()
+                .collect())
         );
     }
 }


### PR DESCRIPTION
- `targets` is now a HashSet to avoid duplicated targets
- `extra_crates` is now a HashSet to avoid duplicated crates
- Add a check in Windows for users installing any version of esp-idf that verifies that is being installed for all the targets. (At the moment installing for not-all targets, fails)
- Environment variable setup is moved into the install fns so install fn has less noise.
- Check if a crate is installed before installing it
- Use cmd! instead of std::process
- Minor cleanups
